### PR TITLE
log child termination signal in stderr

### DIFF
--- a/subproc.cc
+++ b/subproc.cc
@@ -322,7 +322,7 @@ static int reapProc(nsjconf_t* nsjconf, pid_t pid, bool should_wait = false) {
 			LOG_I("pid=%d (%s) terminated with signal: %s (%d), (PIDs left: %d)", pid,
 			    remote_txt.c_str(), util::sigName(WTERMSIG(status)).c_str(),
 			    WTERMSIG(status), countProc(nsjconf) - 1);
-			fprintf(stderr, "Program terminated with signal: %s", util::sigName(WTERMSIG(status)).c_str());
+			fprintf(stderr, "Program terminated with signal: %s\n", util::sigName(WTERMSIG(status)).c_str());
 			removeProc(nsjconf, pid);
 			return 128 + WTERMSIG(status);
 		}

--- a/subproc.cc
+++ b/subproc.cc
@@ -322,6 +322,7 @@ static int reapProc(nsjconf_t* nsjconf, pid_t pid, bool should_wait = false) {
 			LOG_I("pid=%d (%s) terminated with signal: %s (%d), (PIDs left: %d)", pid,
 			    remote_txt.c_str(), util::sigName(WTERMSIG(status)).c_str(),
 			    WTERMSIG(status), countProc(nsjconf) - 1);
+			fprintf(stderr, "Program terminated with signal: %s", util::sigName(WTERMSIG(status)).c_str());
 			removeProc(nsjconf, pid);
 			return 128 + WTERMSIG(status);
 		}


### PR DESCRIPTION
Logs signal in stderr so the user can see what went wrong, as requested in https://github.com/compiler-explorer/compiler-explorer/issues/3567

Based on nsjail 3.0, so it's the absolute minimum of change compared to what we use now https://github.com/compiler-explorer/infra/blob/main/setup-node.sh#L78
