### PR TITLE
Ce mount propagation

### DIFF
--- a/cmdline.cc
+++ b/cmdline.cc
@@ -408,7 +408,7 @@ static bool setupMounts(nsjconf_t *nsjconf) {
 			/* is_dir= */ mnt::NS_DIR_YES,
 			/* is_mandatory= */ true, /* src_env= */ "",
 			/* dst_env= */ "", /* src_content= */ "",
-			/* is_symlink= */ false)) {
+			/* is_symlink= */ false, /* needs_mount_propagation= */ false)) {
 			return false;
 		}
 	} else {
@@ -416,7 +416,7 @@ static bool setupMounts(nsjconf_t *nsjconf) {
 			/* options= */ "", nsjconf->is_root_rw ? 0 : MS_RDONLY,
 			/* is_dir= */ mnt::NS_DIR_YES,
 			/* is_mandatory= */ true, /* src_env= */ "", /* dst_env= */ "",
-			/* src_content= */ "", /* is_symlink= */ false)) {
+			/* src_content= */ "", /* is_symlink= */ false, /* needs_mount_propagation= */ false)) {
 			return false;
 		}
 	}
@@ -426,7 +426,7 @@ static bool setupMounts(nsjconf_t *nsjconf) {
 			/* is_dir= */ mnt::NS_DIR_YES,
 			/* is_mandatory= */ true, /* src_env= */ "",
 			/* dst_env= */ "", /* src_content= */ "",
-			/* is_symlink= */ false)) {
+			/* is_symlink= */ false, /* needs_mount_propagation= */ false)) {
 			return false;
 		}
 	}
@@ -806,7 +806,7 @@ std::unique_ptr<nsjconf_t> parseArgs(int argc, char *argv[]) {
 				/* options= */ "", MS_BIND | MS_REC | MS_PRIVATE | MS_RDONLY,
 				/* is_dir= */ mnt::NS_DIR_MAYBE, /* is_mandatory= */ true,
 				/* src_env= */ "", /* dst_env= */ "", /* src_content= */ "",
-				/* is_symlink= */ false)) {
+				/* is_symlink= */ false, /* needs_mount_propagation= */ false)) {
 				return nullptr;
 			}
 		}; break;
@@ -821,7 +821,7 @@ std::unique_ptr<nsjconf_t> parseArgs(int argc, char *argv[]) {
 				/* options= */ "", MS_BIND | MS_REC | MS_PRIVATE,
 				/* is_dir= */ mnt::NS_DIR_MAYBE, /* is_mandatory= */ true,
 				/* src_env= */ "", /* dst_env= */ "", /* src_content= */ "",
-				/* is_symlink= */ false)) {
+				/* is_symlink= */ false, /* needs_mount_propagation= */ false)) {
 				return nullptr;
 			}
 		}; break;
@@ -830,7 +830,7 @@ std::unique_ptr<nsjconf_t> parseArgs(int argc, char *argv[]) {
 				/* options= */ "size=4194304", 0,
 				/* is_dir= */ mnt::NS_DIR_YES, /* is_mandatory= */ true,
 				/* src_env= */ "", /* dst_env= */ "", /* src_content= */ "",
-				/* is_symlink= */ false)) {
+				/* is_symlink= */ false, /* needs_mount_propagation= */ false)) {
 				return nullptr;
 			}
 		}; break;
@@ -852,7 +852,7 @@ std::unique_ptr<nsjconf_t> parseArgs(int argc, char *argv[]) {
 				/* options= */ options, /* flags= */ 0,
 				/* is_dir= */ mnt::NS_DIR_MAYBE, /* is_mandatory= */ true,
 				/* src_env= */ "", /* dst_env= */ "", /* src_content= */ "",
-				/* is_symlink= */ false)) {
+				/* is_symlink= */ false, /* needs_mount_propagation= */ false)) {
 				return nullptr;
 			}
 		}; break;
@@ -864,7 +864,7 @@ std::unique_ptr<nsjconf_t> parseArgs(int argc, char *argv[]) {
 				/* options= */ "", /* flags= */ 0,
 				/* is_dir= */ mnt::NS_DIR_NO, /* is_mandatory= */ true,
 				/* src_env= */ "", /* dst_env= */ "", /* src_content= */ "",
-				/* is_symlink= */ true)) {
+				/* is_symlink= */ true, /* needs_mount_propagation= */ false)) {
 				return nullptr;
 			}
 		}; break;

--- a/config.cc
+++ b/config.cc
@@ -225,6 +225,7 @@ static bool parseInternal(nsjconf_t* nsjconf, const nsjail::NsJailConfig& njc) {
 		flags |= njc.mount(i).noexec() ? MS_NOEXEC : 0;
 		bool is_mandatory = njc.mount(i).mandatory();
 		bool is_symlink = njc.mount(i).is_symlink();
+		bool needs_mount_propagation = njc.mount(i).needs_mount_propagation();
 		std::string src_content = njc.mount(i).src_content();
 
 		mnt::isDir_t is_dir = mnt::NS_DIR_MAYBE;
@@ -233,7 +234,7 @@ static bool parseInternal(nsjconf_t* nsjconf, const nsjail::NsJailConfig& njc) {
 		}
 
 		if (!mnt::addMountPtTail(nsjconf, src, dst, fstype, options, flags, is_dir,
-			is_mandatory, src_env, dst_env, src_content, is_symlink)) {
+			is_mandatory, src_env, dst_env, src_content, is_symlink, needs_mount_propagation)) {
 			LOG_E("Couldn't add mountpoint for src:%s dst:%s", QC(src), QC(dst));
 			return false;
 		}

--- a/config.proto
+++ b/config.proto
@@ -57,6 +57,8 @@ message MountPt {
 	optional bool nodev = 14 [default = false];
 	/* Is it a noexec mount */
 	optional bool noexec = 15 [default = false];
+	/* Requires mount propagation for autofs/systemd mounts */
+	optional bool needs_mount_propagation = 16 [default = false];
 }
 enum RLimit {
 	VALUE = 0; /* Use the provided value */

--- a/config.proto
+++ b/config.proto
@@ -57,7 +57,9 @@ message MountPt {
 	optional bool nodev = 14 [default = false];
 	/* Is it a noexec mount */
 	optional bool noexec = 15 [default = false];
-	/* Requires mount propagation for autofs/systemd mounts */
+	/* Requires mount propagation for autofs/systemd mounts.
+	   WARNING: This makes ALL mounts in the container slaves to the host,
+	   not just this specific mount. Use only for trusted environments. */
 	optional bool needs_mount_propagation = 16 [default = false];
 }
 enum RLimit {

--- a/mnt.cc
+++ b/mnt.cc
@@ -386,9 +386,20 @@ static bool initCloneNs(nsjconf_t* nsjconf) {
 		return false;
 	}
 
-	/* Make changes to / (recursively) private, to avoid changing the global mount ns */
-	if (mount("/", "/", NULL, MS_REC | MS_PRIVATE, NULL) == -1) {
-		PLOG_E("mount('/', '/', NULL, MS_REC|MS_PRIVATE, NULL)");
+	bool needs_mount_propagation = false;
+	for (const auto& mpt : nsjconf->mountpts) {
+		if (mpt.needs_mount_propagation) {
+			needs_mount_propagation = true;
+			LOG_I("Mount %s requires propagation - using MS_SLAVE for root", mpt.dst.c_str());
+			break;
+		}
+	}
+
+	unsigned long propagation_flag = needs_mount_propagation ? MS_SLAVE : MS_PRIVATE;
+	const auto propagation_name = needs_mount_propagation ? "MS_SLAVE" : "MS_PRIVATE";
+
+	if (mount("/", "/", NULL, MS_REC | propagation_flag, NULL) == -1) {
+		PLOG_E("mount('/', '/', NULL, MS_REC|%s, NULL)", propagation_name);
 		return false;
 	}
 	if (mount(NULL, destdir->c_str(), "tmpfs", 0, "size=16777216") == -1) {
@@ -531,7 +542,7 @@ bool initNs(nsjconf_t* nsjconf) {
 static bool addMountPt(mount_t* mnt, const std::string& src, const std::string& dst,
     const std::string& fstype, const std::string& options, uintptr_t flags, isDir_t is_dir,
     bool is_mandatory, const std::string& src_env, const std::string& dst_env,
-    const std::string& src_content, bool is_symlink) {
+    const std::string& src_content, bool is_symlink, bool needs_mount_propagation) {
 	if (!src_env.empty()) {
 		const char* e = getenv(src_env.c_str());
 		if (e == nullptr) {
@@ -559,6 +570,7 @@ static bool addMountPt(mount_t* mnt, const std::string& src, const std::string& 
 	mnt->is_mandatory = is_mandatory;
 	mnt->mounted = false;
 	mnt->src_content = src_content;
+	mnt->needs_mount_propagation = needs_mount_propagation;
 
 	switch (is_dir) {
 	case NS_DIR_YES:
@@ -589,10 +601,10 @@ static bool addMountPt(mount_t* mnt, const std::string& src, const std::string& 
 bool addMountPtHead(nsjconf_t* nsjconf, const std::string& src, const std::string& dst,
     const std::string& fstype, const std::string& options, uintptr_t flags, isDir_t is_dir,
     bool is_mandatory, const std::string& src_env, const std::string& dst_env,
-    const std::string& src_content, bool is_symlink) {
+    const std::string& src_content, bool is_symlink, bool needs_mount_propagation) {
 	mount_t mnt;
 	if (!addMountPt(&mnt, src, dst, fstype, options, flags, is_dir, is_mandatory, src_env,
-		dst_env, src_content, is_symlink)) {
+		dst_env, src_content, is_symlink, needs_mount_propagation)) {
 		return false;
 	}
 	nsjconf->mountpts.insert(nsjconf->mountpts.begin(), mnt);
@@ -602,10 +614,10 @@ bool addMountPtHead(nsjconf_t* nsjconf, const std::string& src, const std::strin
 bool addMountPtTail(nsjconf_t* nsjconf, const std::string& src, const std::string& dst,
     const std::string& fstype, const std::string& options, uintptr_t flags, isDir_t is_dir,
     bool is_mandatory, const std::string& src_env, const std::string& dst_env,
-    const std::string& src_content, bool is_symlink) {
+    const std::string& src_content, bool is_symlink, bool needs_mount_propagation) {
 	mount_t mnt;
 	if (!addMountPt(&mnt, src, dst, fstype, options, flags, is_dir, is_mandatory, src_env,
-		dst_env, src_content, is_symlink)) {
+		dst_env, src_content, is_symlink, needs_mount_propagation)) {
 		return false;
 	}
 	nsjconf->mountpts.push_back(mnt);

--- a/mnt.cc
+++ b/mnt.cc
@@ -390,7 +390,8 @@ static bool initCloneNs(nsjconf_t* nsjconf) {
 	for (const auto& mpt : nsjconf->mountpts) {
 		if (mpt.needs_mount_propagation) {
 			needs_mount_propagation = true;
-			LOG_I("Mount %s requires propagation - using MS_SLAVE for root", mpt.dst.c_str());
+			LOG_W("Mount %s requires propagation - setting ALL mounts as slaves to host", mpt.dst.c_str());
+			LOG_W("SECURITY WARNING: All bind mounts will receive events from host filesystem");
 			break;
 		}
 	}
@@ -398,9 +399,15 @@ static bool initCloneNs(nsjconf_t* nsjconf) {
 	unsigned long propagation_flag = needs_mount_propagation ? MS_SLAVE : MS_PRIVATE;
 	const auto propagation_name = needs_mount_propagation ? "MS_SLAVE" : "MS_PRIVATE";
 
+	if (needs_mount_propagation) {
+		LOG_W("Setting root filesystem to MS_SLAVE - ALL mounts become slaves to host");
+	}
 	if (mount("/", "/", NULL, MS_REC | propagation_flag, NULL) == -1) {
 		PLOG_E("mount('/', '/', NULL, MS_REC|%s, NULL)", propagation_name);
 		return false;
+	}
+	if (needs_mount_propagation) {
+		LOG_W("Root filesystem now MS_SLAVE - mount events from host will propagate");
 	}
 	if (mount(NULL, destdir->c_str(), "tmpfs", 0, "size=16777216") == -1) {
 		PLOG_E("mount(%s, 'tmpfs')", QC(*destdir));

--- a/mnt.h
+++ b/mnt.h
@@ -41,11 +41,11 @@ bool initNs(nsjconf_t* nsjconf);
 bool addMountPtHead(nsjconf_t* nsjconf, const std::string& src, const std::string& dst,
     const std::string& fstype, const std::string& options, uintptr_t flags, isDir_t is_dir,
     bool is_mandatory, const std::string& src_env, const std::string& dst_env,
-    const std::string& src_content, bool is_symlink);
+    const std::string& src_content, bool is_symlink, bool needs_mount_propagation);
 bool addMountPtTail(nsjconf_t* nsjconf, const std::string& src, const std::string& dst,
     const std::string& fstype, const std::string& options, uintptr_t flags, isDir_t is_dir,
     bool is_mandatory, const std::string& src_env, const std::string& dst_env,
-    const std::string& src_content, bool is_symlink);
+    const std::string& src_content, bool is_symlink, bool needs_mount_propagation);
 const std::string describeMountPt(const mount_t& mpt);
 
 }  // namespace mnt

--- a/nsjail.h
+++ b/nsjail.h
@@ -66,6 +66,7 @@ struct mount_t {
 	bool is_symlink;
 	bool is_mandatory;
 	bool mounted;
+	bool needs_mount_propagation;
 };
 
 struct idmap_t {


### PR DESCRIPTION
I tried adding it to just the individual filesystems but that didn't work.

we should be OK in ce because:

- Read-only autofs-controlled mount point
- Content-addressed paths (unpredictable)
- MS_SLAVE for one-way propagation only
